### PR TITLE
temporary fix for last line in lbl models + stylistic changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -422,6 +422,7 @@ async def handle_edit_command(default_chat_history, editor_chat_history, filepat
             editor_chat_history.append({"role": "assistant", "content": result})
 
             if is_diff_on:
+                print("\n🔍 DIFF:")
                 display_diff(current_content, result)  # Show final diff if it's on
 
             # Write the changes to the file only after the entire editing process

--- a/main.py
+++ b/main.py
@@ -384,6 +384,8 @@ async def handle_edit_command(default_chat_history, editor_chat_history, filepat
             Instructions: {default_instructions}
 
             Follow only instructions applicable to {filepath}. Output ONLY the new code. No explanations. DO NOT ADD ANYTHING ELSE. no type of file at the beginning of the file like ```python etq. no ``` at the end of the file.
+
+            Add an empty line symbol to the end.
             """
 
             editor_chat_history.append({"role": "user", "content": edit_message})

--- a/main.py
+++ b/main.py
@@ -391,9 +391,6 @@ async def handle_edit_command(default_chat_history, editor_chat_history, filepat
             if current_content.startswith("❌"):
                 return default_chat_history, editor_chat_history
 
-            if current_content.startswith("❌"):
-                return default_chat_history, editor_chat_history
-
             lines = current_content.splitlines(keepends=True)
             buffer = ""
             edited_lines = lines.copy()  # Create a copy to store edited lines


### PR DESCRIPTION
In fdcd31e3f35c310ecdc9d193508af6eee993b4a8 I added a temporary quick fix for the problem of losing the last line of code using lbl models. I don't think we would have the issue if the lbl models would answer by default with an empty line at the end of the response. From what I see is the issue the separation of the `buffer` in the streamed answer: https://github.com/lbnl-science-it/omni-engineer-lbl/blob/d911ad22a0a698f7196e0135c15a37fe16e99bc2/main.py#L412 

The first 2 commits (45848420f1af33ad98952d9bafaff151545aff90 and 7837bc15a6ff6d4207071d5b4af1e9ca77e4bfc8) are stylistic changes. 